### PR TITLE
Transforms should be listed alongside animations and transitions.

### DIFF
--- a/pages/wont-fix.md
+++ b/pages/wont-fix.md
@@ -40,7 +40,7 @@ which generate console warnings.
 * [#7535](http://bugs.jquery.com/ticket/7535)
 * [#10531](http://bugs.jquery.com/ticket/10531)
 
-## CSS Transition/Animation
+## CSS Transition/Animation/Transforms
 
 While some browsers do provide native means of doing CSS animations, most of
 that has been encapsulated into plugins. We will continue to recommend that


### PR DESCRIPTION
Seems like transforms should be included in this section, especially since one of the plugins is for transforms.

We discussed this for jQuery UI here http://bugs.jqueryui.com/ticket/6844#comment:18 but I didn't think it was necessarily worth mentioning.
