### PR TITLE
Updated broken link, fixes #28

### DIFF
--- a/pages/markup-conventions.html
+++ b/pages/markup-conventions.html
@@ -555,5 +555,5 @@ var foo = &quot;bar&quot;;
 <p>We are using the Zurb Foundation grid as a basis for the grid. <strong>Please only use this grid inside of the main <a href=
 "#foundation">foundation</a></strong> mentioned above (i.e. in the <code>#content</code> or <code>#sidebar</code>).</p>
 
-<p>We'll have a reference eventually, but for now <a href="http://foundation.zurb.com/docs/grid.php" target="_blank">go here</a> to see how to use the
+<p>We'll have a reference eventually, but for now <a href="http://foundation.zurb.com/docs/components/grid.html" target="_blank">go here</a> to see how to use the
 grid.</p>


### PR DESCRIPTION
The new link to the Zurb Foundation Grid reference docs is now http://foundation.zurb.com/docs/components/grid.html

This pull request fixes #28.
