### PR TITLE
Branching: Pop stash after creating branch

### DIFF
--- a/pages/commits-and-pull-requests.md
+++ b/pages/commits-and-pull-requests.md
@@ -57,13 +57,17 @@ If your branch pertains to a particular issue, it can be useful to name the bran
 $ git checkout -b 151-remove-build-artifact
 ```
 
-In order to facilitate cleaner and easier merges, it can be useful to "branch late." Rather than branching the second you know you plan to make a change, work on your change until you're ready to commit. At that point, you can quickly [stash](http://git-scm.com/book/en/Git-Tools-Stashing) your work, pull the upstream master, and then branch and commit.
+In order to facilitate cleaner and easier merges, it can be useful to "branch late."
+Rather than branching the second you know you plan to make a change, work on your
+change until you're ready to commit. At that point, you can quickly
+[stash](http://git-scm.com/book/en/Git-Tools-Stashing) your work, pull the upstream
+master, and then branch and commit.
 
 ``` bash
 $ git stash
 $ git pull upstream master
-$ git stash pop
 $ git checkout -b 123-header-shadows
+$ git stash pop
 $ git add style.css
 $ git commit -m "Clean up header shadows. Fixes #123."
 ```


### PR DESCRIPTION
Though the end result is the same, setting up the branch first
ensures the working copy (and potential merge conflicts) are dealt
with in the context of the proper branch (instead of relying on
git-checkout to preserve and re-apply the dirty tree after
switching branches).
