### PR TITLE
JS Style Guide: Add rules for constructor invocation

### DIFF
--- a/pages/style-guide/js.md
+++ b/pages/style-guide/js.md
@@ -360,18 +360,18 @@ var fn = function() {
 
 ## Constructors
 
-Constructors should always be invoked as functions (e.g., with argument lists), even when _not_ supplying arguments.
+Constructor functions should always be invoked with argument lists, even when such lists are empty.
 
 ```js
 throw new Error();
 when = time || new Date();
 ```
 
-When property access or method invocation is immediately performed on the result, clarify precedence with wrapping parentheses.
+When property access or method invocation is immediately performed on the result of a constructor function, clarify precedence with wrapping parentheses.
 
 ```js
-detachedMode = (new TemplateFactory( settings )).nodeType === 11;
-match = (new RegExp( pattern )).exec( input );
+detachedMode = ( new TemplateFactory( settings ) ).nodeType === 11;
+match = ( new RegExp( pattern ) ).exec( input );
 ```
 
 ## Equality

--- a/pages/style-guide/js.md
+++ b/pages/style-guide/js.md
@@ -358,6 +358,22 @@ var fn = function() {
 	};
 ```
 
+## Constructors
+
+Constructors should always be invoked as functions (e.g., with argument lists), even when _not_ supplying arguments.
+
+```js
+throw new Error();
+when = time || new Date();
+```
+
+When property access or method invocation is immediately performed on the result, clarify precedence with wrapping parentheses.
+
+```js
+detachedMode = (new TemplateFactory( settings )).nodeType === 11;
+match = (new RegExp( pattern )).exec( input );
+```
+
 ## Equality
 
 Strict equality checks (`===`) must be used in favor of abstract equality checks (`==`). The _only_ exception is when checking for `undefined` and `null` by way of `null`.


### PR DESCRIPTION
Ref https://github.com/jquery/jquery/pull/1856#issuecomment-65346516

These reflect my personal preference for explicit clarity (especially around whitespace-preceding keyword operators) and could easily be changed; I just want to get some clear guidelines published.