### PR TITLE
CSS Style Guide - Add !important notice

### DIFF
--- a/pages/style-guide/css.md
+++ b/pages/style-guide/css.md
@@ -30,7 +30,7 @@ The following common options must be used in all projects with css:
 	"compatible-vendor-prefixes": false,
 	"duplicate-background-images": false,
 	"import": false,
-	"important": false,
+	"important": true,
 	"outline-none": false,
 	"overqualified-elements": false,
 	"text-indent": false
@@ -98,6 +98,7 @@ font-weight:strong;
  - Omit leading zeros in decimal values.
  - Use double quotes instead of single quotes.
  - Always have a semicolon at the end of each declaration.
+ - Avoid the use `!important`.
 
 
 ```css

--- a/pages/style-guide/css.md
+++ b/pages/style-guide/css.md
@@ -98,7 +98,7 @@ font-weight:strong;
  - Omit leading zeros in decimal values.
  - Use double quotes instead of single quotes.
  - Always have a semicolon at the end of each declaration.
- - Avoid the use `!important`.
+ - Avoid the use of `!important`.
 
 
 ```css


### PR DESCRIPTION
Added the `!important` rule to csslint as suggested in #96.  However, since this is currently not standard practice, additional issues will need to be created in other projects to add this to the project's csslint file.  

UI and Mobile currently contain !important in the css, so that css will need to be refactored to not need `!important` in order for new csslint rules to pass.