### PR TITLE
JS Style Guide: Remove spacing exceptions

### DIFF
--- a/pages/style-guide/js.md
+++ b/pages/style-guide/js.md
@@ -190,34 +190,23 @@ foo( options, object[ property ] );
 foo( node, "property", 2 );
 
 foo( [ a, b ], "property", { c: d } );
-```
 
-Exceptions:
+foo( { a: "alpha", b: "beta" } );
 
-```js
-// Function with a single line object or array as the sole argument:
-// No space on either side of the argument
-foo({ a: "alpha", b: "beta" });
-foo([ a, b ]);
+foo( [ a, b ] );
 
-// Function with a multiline callback, object, or array as the sole argument:
-// No space on either side of the argument
-foo({
+foo( {
 	a: "alpha",
 	b: "beta"
-});
+} );
 
-// Function with a multiline callback, object, or array as the first argument:
-// No space before the first argument
-foo(function() {
+foo( function() {
 	// Do stuff
 }, options );
 
-// Function with a multiline callback, object, or array as the last argument:
-// No space after after the last argument
 foo( data, function() {
 	// Do stuff
-});
+} );
 ```
 
 


### PR DESCRIPTION
Motivation: 
1. A simple style guide that makes it easy for contributors to contribute and easy for style guide enforcement software to enforce.
2. Arguments about "what looks good" are subjective. What should dictate style is principal of least surprise and least exceptions to the rule, except where the exceptions are *objectively* better or necessary.

Yes, this would require some changes to current code. @jzaefferer and I can handle that easily with esformatter and jscs should this be approved.

Thoughts? /cc @dmethvin @scottgonzalez @timmywil @gibson042 @markelog 