### PR TITLE
Fixed some bad links

### DIFF
--- a/pages/bug-reports.md
+++ b/pages/bug-reports.md
@@ -14,7 +14,6 @@ If you are new to jQuery, it is usually a much better idea to ask for help first
 
 Make sure you have reproduced the bug with all browser extensions disabled, as these can sometimes cause things to break in interesting and unpredictable ways.
 
-
 In Firefox, restart in [safe mode](http://kb.mozillazine.org/Safe_mode). In Internet Explorer, follow [these instructions](https://support.microsoft.com/en-us/kb/298931). In Chrome, enter `chrome://extensions` in your address bar and disable all extensions. In Safari, go to Safari -> Preferences -> Extensions and move the slider to "Off".
 
 ### Try a Newer Version

--- a/pages/bug-reports.md
+++ b/pages/bug-reports.md
@@ -14,7 +14,8 @@ If you are new to jQuery, it is usually a much better idea to ask for help first
 
 Make sure you have reproduced the bug with all browser extensions disabled, as these can sometimes cause things to break in interesting and unpredictable ways.
 
-In Firefox, restart in [safe mode](http://kb.mozillazine.org/Safe_mode). In Internet Explorer, follow [these instructions](http://support.microsoft.com/kb/298931). In Chrome, enter `chrome://extensions` in your address bar and disable all extensions. In Safari, go to Safari -> Preferences -> Extensions and move the slider to "Off".
+
+In Firefox, restart in [safe mode](http://kb.mozillazine.org/Safe_mode). In Internet Explorer, follow [these instructions](https://support.microsoft.com/en-us/kb/298931). In Chrome, enter `chrome://extensions` in your address bar and disable all extensions. In Safari, go to Safari -> Preferences -> Extensions and move the slider to "Off".
 
 ### Try a Newer Version
 

--- a/pages/documentation.md
+++ b/pages/documentation.md
@@ -28,7 +28,7 @@ If you actually want to make the fixes and improvements, then
 you'll need to [fork](https://help.github.com/articles/fork-a-repo) the
 repositories you'd like to work on. Once you've made changes you'd like
 reviewed for integration, submit a [pull
-request](http://help.github.com/send-pull-requests/). However, we recommend
+request](https://help.github.com/send-pull-requests/). However, we recommend
 that you file issues for new "features" and significant changes before actually
 getting to work. For more information on maintaining your fork and strategies on
 committing, see the [Commits and Pull Requests](/commits-and-pull-requests/)

--- a/pages/markup-conventions.html
+++ b/pages/markup-conventions.html
@@ -10,7 +10,7 @@ Please adhere to these conventions if you are <a href="/web-sites/">working on a
 <p>The jQuery sites are built with a number of existing libraries and tools. The list below will attempt to catalog the most important ones:</p>
 
 <ul>
-	<li><a href="http://html5boilerplate.com" target="_blank">HTML5 Boilerplate</a></li>
+	<li><a href="https://html5boilerplate.com" target="_blank">HTML5 Boilerplate</a></li>
 	<li><a href="http://modernizr.com" target="_blank">Modernizr</a></li>
 	<li><a href="https://github.com/scottjehl/Respond" target="_blank">Respond JS</a></li>
 	<li><a href="http://fortawesome.github.com/Font-Awesome/" target="_blank">Font Awesome</a></li>

--- a/pages/open-source.md
+++ b/pages/open-source.md
@@ -171,4 +171,4 @@ stuck with your changes awaiting approval. This can lead to all kinds of messes
 like not being able to work on other items or creating branches off of the
 modified master branch and thus including possibly unapproved changes in later
 pull requests. Git is a powerful tool and we could write an entire article on
-it ... oh wait, [we did](../"commits-and-pull-requests/).
+it ... oh wait, [we did](../commits-and-pull-requests/).

--- a/pages/open-source.md
+++ b/pages/open-source.md
@@ -171,4 +171,4 @@ stuck with your changes awaiting approval. This can lead to all kinds of messes
 like not being able to work on other items or creating branches off of the
 modified master branch and thus including possibly unapproved changes in later
 pull requests. Git is a powerful tool and we could write an entire article on
-it ... oh wait, [we did](../commits-and-pull-requests).
+it ... oh wait, [we did](../"commits-and-pull-requests/).

--- a/pages/support.md
+++ b/pages/support.md
@@ -63,7 +63,7 @@ Live, interactive support for all jQuery Foundation projects takes place 24/7
 in the [#jquery](irc://irc.freenode.net/#jquery) IRC channel on
 [Freenode](http://irc.freenode.net), and it's a great place to give and receive
 help with small- to medium-sized problems in all sorts of environments. (If you're unfamiliar
-with Internet Relay Chat, take a look at our [IRC Help](http://irc.jquery.org/irc-help) page for
+with Internet Relay Chat, take a look at our [IRC Help](http://irc.jquery.org/irc-help/) page for
 information about how to get connected and what to expect once you're there.)
 
 ### Forums

--- a/pages/web-sites.md
+++ b/pages/web-sites.md
@@ -149,7 +149,7 @@ If you actually want to make commits to make the fixes and improvements, then
 you'll need to [fork](https://help.github.com/articles/fork-a-repo) the content
 repositories you'd like to work on.  When you have changes you'd like to have
 reviewed for integration, submit a [pull
-request](http://help.github.com/send-pull-requests/). However, we recommend
+request](https://help.github.com/send-pull-requests/). However, we recommend
 that you file issues for new "features" and significant changes before actually
 getting to work. For more information on maintaining your fork and strategies on
 commiting, see the [Commits and Pull Requests](/commits-and-pull-requests/)
@@ -158,7 +158,7 @@ guide.
 You'll note that it is possible to make content changes without setting up a
 local WordPress instance. You won't be able to preview your changes as they'll
 appear on the site, and you won't be able to run `grunt deploy`, which means
-you can't be 100% sure that the content will build successfuly. We will accept
+you can't be 100% sure that the content will build successfully. We will accept
 pull requests on content from users who haven't had a chance to test locally, but
 encourage anyone who's planning to contribute regularly to get configured
 for deploying and testing locally.


### PR DESCRIPTION
@arschmitz  spiderJS reports a **403** error at http://www.bleepingcomputer.com/tutorials/windows-command-prompt-introduction/

### Remark
It seems all sites are migrating to HTTPS. As mentioned at https://github.com/jquery/jquery.com/pull/91#issue-63863412, the use of **SSL is encouraged**. I also noticed that all jQuery sites have valid SSL certificates. Why aren't all HTTP requests redirected to use the HTTPS protocol?

**PS: I don't know  the best place to raise this issue**